### PR TITLE
Update abstract.asciidoc

### DIFF
--- a/docs/partials/abstract.asciidoc
+++ b/docs/partials/abstract.asciidoc
@@ -54,8 +54,7 @@ the United Kingdom as at February 2017.
 |Revision date |March 2019
 |===
 
-Corresponding element in other standards...
-
+.Corresponding element in other standards...
 [%collapsible]
 ====
 |===
@@ -80,8 +79,7 @@ Change history...
 
 [[history4]]
 
-Encoding guidelines...
-
+.Encoding guidelines...
 [%collapsible]
 ====
 |===
@@ -101,8 +99,7 @@ endif::[]
 |===
 ====
 
-Metadata errors observed...
-
+.Metadata errors observed...
 [%collapsible]
 ====
 No error information available


### PR DESCRIPTION
https://docs.asciidoctor.org/asciidoc/latest/blocks/collapsible/ suggests that we can provide our own 'clickable text' instead of the default "Details". I have only done that to this element as an experiment to check it works.